### PR TITLE
Update mkdocs.yml for versioning and edit URI adjustments

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -46,6 +46,13 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
 
+      - name: Update mkdocs.yml
+        run: |
+          sed -i "s\edit_uri: edit/main/docs/\edit_uri: edit/$VERSION_NAME/docs/\" mkdocs.yml
+          if [ "$BRANCH_NAME" = "main" ]; then
+            sed -i "s/version_selector: true/version_selector: false/" mkdocs.yml
+          fi
+
       - name: Deploy docs with mike
         run: |
           if [ "$BRANCH_NAME" = "main" ]; then

--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Update mkdocs.yml
         run: |
-          sed -i "s\edit_uri: edit/main/docs/\edit_uri: edit/$VERSION_NAME/docs/\" mkdocs.yml
+          sed -i "s|edit_uri: edit/main/docs/|edit_uri: edit/$VERSION_NAME/docs/|" mkdocs.yml
           if [ "$BRANCH_NAME" = "main" ]; then
             sed -i "s/version_selector: true/version_selector: false/" mkdocs.yml
           fi

--- a/README.md
+++ b/README.md
@@ -50,7 +50,5 @@ We are also using some extensions:
 
 Live web site is made available at:  https://cioos-siooc.github.io/cioos-siooc-guide/
 
-## Versioned Documentation (mike)
-
 We use [mike](https://github.com/jimporter/mike) to manage multiple published versions of the site on GitHub Pages.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ extra:
     src: "https://plausible.cioos.ca/js/script.file-downloads.hash.outbound-links.local.js"
 
 plugins:
+  - mike:
+      version_selector: true
   - material-plausible
   - search:
       lang: fr


### PR DESCRIPTION
This pull request introduces updates to the documentation deployment workflow and configuration to better support versioned documentation and branch-specific settings. The main changes involve dynamically updating the `mkdocs.yml` configuration during the build process and enabling the `mike` plugin for versioned docs.

**Documentation workflow improvements:**

* The build workflow now updates the `edit_uri` in `mkdocs.yml` to point to the correct branch, ensuring that edit links in the documentation reflect the current version being built.
* When building documentation for the `main` branch, the workflow sets `version_selector` to `false` in `mkdocs.yml`, hiding the version selector for the main docs.

**MkDocs configuration changes:**

* The `mike` plugin is now enabled in `mkdocs.yml` with `version_selector: true`, supporting versioned documentation.